### PR TITLE
feat: parse PAPI player context based placeholders in broadcast messages

### DIFF
--- a/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
+++ b/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
@@ -6,8 +6,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.nonxedy.nonchat.util.integration.external.IntegrationUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
 import com.nonxedy.nonchat.Nonchat;
@@ -62,27 +64,35 @@ public class BroadcastManager {
         }
     }
 
-    @SuppressWarnings("deprecation") // broadcastMessage() is deprecated but required for legacy server compatibility
     public void broadcast(CommandSender sender, String message) {
         try {
-            Component formatted;
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                // Process PAPI placeholders for each player individually
+                String parsedMessage = IntegrationUtil.processPlaceholders(player, message);
 
-            // Check if message contains MiniMessage tags
-            if (ColorUtil.containsMiniMessageTags(message)) {
-                // Parse with MiniMessage for full tag support (including click events)
-                formatted = ColorUtil.parseMiniMessageComponent(message);
-            } else {
-                // Use LinkDetector to make links clickable for legacy messages
-                formatted = LinkDetector.makeLinksClickable(message);
+                Component formatted;
+                // Check if message contains MiniMessage tags
+                if (ColorUtil.containsMiniMessageTags(parsedMessage)) {
+                    formatted = ColorUtil.parseMiniMessageComponent(parsedMessage);
+                } else {
+                    // Use LinkDetector to make links clickable for legacy messages
+                    formatted = LinkDetector.makeLinksClickable(parsedMessage);
+                }
+                // Try to use Adventure API first
+                player.sendMessage(formatted);
             }
 
-            // Try to use Adventure API first
-            Bukkit.broadcast(formatted);
+            // Console log using the raw message (no player context for PAPI)
+            String consoleMessage = ColorUtil.stripAllColors(message);
+            plugin.getLogger().info(consoleMessage);
+
         } catch (NoSuchMethodError e) {
-            // Fall back to traditional Bukkit broadcast if Adventure API is not available
+            // Fall back to traditional Bukkit sendMessage if Adventure API is not available
             plugin.logError("Adventure API isn't available: " + e.getMessage());
-            String legacyMessage = ColorUtil.parseColor(message);
-            Bukkit.broadcastMessage(legacyMessage);
+            for (Player player : Bukkit.getOnlinePlayers()) {
+                String parsedMessage = IntegrationUtil.processPlaceholders(player, message);
+                player.sendMessage(ColorUtil.parseColor(parsedMessage));
+            }
         }
     }
 


### PR DESCRIPTION
Broadcast messages now process PlaceholderAPI placeholders per-player before formatting, allowing player-specific placeholders like `%player_name%` or `%vault_eco_balance%` to resolve correctly for each recipient. 

This also removes the deprecated broadcastMessage method, but still maintaining compatibility with legacy servers.

<img width="483" height="137" alt="image" src="https://github.com/user-attachments/assets/b1576af4-a3e7-4645-950b-a8839fa73adc" />
<img width="423" height="49" alt="image" src="https://github.com/user-attachments/assets/be3e4266-b938-4474-b2b1-4a46d3aa1c23" />

An idea for the feature would be to add a toggle switch for enabling/disabling the broadcast messages for console, since PAPI player context based placeholders aren't parsed there and printed raw, leading to bad looking messages. 


<img width="523" height="15" alt="image" src="https://github.com/user-attachments/assets/e4149d3b-0913-4e8e-93f6-8fe98a9849d9" />
