### PR TITLE
feat(broadcast): add per-message console display control

### DIFF
--- a/src/main/java/com/nonxedy/nonchat/api/IMessageHandler.java
+++ b/src/main/java/com/nonxedy/nonchat/api/IMessageHandler.java
@@ -1,11 +1,12 @@
 package com.nonxedy.nonchat.api;
 
+import com.nonxedy.nonchat.util.core.broadcast.BroadcastMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public interface IMessageHandler {
     void handleChat(Player player, String message);
     void handlePrivateMessage(Player sender, Player receiver, String message);
-    void handleBroadcast(CommandSender sender, String message);
+    void handleBroadcast(BroadcastMessage message);
     void handleStaffChat(Player sender, String message);
 }

--- a/src/main/java/com/nonxedy/nonchat/api/IMessageHandler.java
+++ b/src/main/java/com/nonxedy/nonchat/api/IMessageHandler.java
@@ -1,7 +1,6 @@
 package com.nonxedy.nonchat.api;
 
 import com.nonxedy.nonchat.util.core.broadcast.BroadcastMessage;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 public interface IMessageHandler {

--- a/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
+++ b/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
@@ -863,6 +863,7 @@ public class PluginConfig {
      * @param enabled Whether the message is enabled
      * @param message The message content
      * @param interval The broadcast interval
+     * @param displayInConsole Whether if the message should be display on console or not
      * @return New BroadcastMessage instance
      */
     public BroadcastMessage createBroadcastMessage(boolean enabled, String message, int interval, boolean displayInConsole) {
@@ -1437,6 +1438,8 @@ public class PluginConfig {
         String currentVersion = savesConfig.getString("version");
         String pluginVersion = plugin.getPluginMeta().getVersion(); // getDescription() is deprecated
         boolean isUpdated = pluginVersion.equals(currentVersion);
+
+
 
         // Only save if version changed
         if (currentVersion == null || !currentVersion.equals(pluginVersion)) {

--- a/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
+++ b/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
@@ -200,6 +200,7 @@ public class PluginConfig {
         config.set("broadcast.example.enabled", true);
         config.set("broadcast.example.message", "This message will be sent every 60 seconds");
         config.set("broadcast.example.interval", 60);
+        config.set("broadcast.example.display-in-console", true);
         
         // Anti-advertisement settings
         config.set("anti-ad.enabled", true);
@@ -748,7 +749,8 @@ public class PluginConfig {
                     messages.put(key, createBroadcastMessage(
                         messageSection.getBoolean("enabled", true),
                         messageSection.getString("message", "Default message"),
-                        messageSection.getInt("interval", 60)
+                        messageSection.getInt("interval", 60),
+                        messageSection.getBoolean("display-in-console", true)
                     ));
                 }
             }
@@ -863,8 +865,8 @@ public class PluginConfig {
      * @param interval The broadcast interval
      * @return New BroadcastMessage instance
      */
-    public BroadcastMessage createBroadcastMessage(boolean enabled, String message, int interval) {
-        return new BroadcastMessage(enabled, message, interval);
+    public BroadcastMessage createBroadcastMessage(boolean enabled, String message, int interval, boolean displayInConsole) {
+        return new BroadcastMessage(enabled, message, interval, displayInConsole);
     }
 
     /**

--- a/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
+++ b/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 
 import com.nonxedy.nonchat.util.integration.external.IntegrationUtil;
 import org.bukkit.Bukkit;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 

--- a/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
+++ b/src/main/java/com/nonxedy/nonchat/core/BroadcastManager.java
@@ -57,14 +57,15 @@ public class BroadcastManager {
 
         for (BroadcastMessage message : messageSequence) {
             BukkitTask task = Bukkit.getScheduler().runTaskTimerAsynchronously(plugin, () -> {
-                broadcast(Bukkit.getConsoleSender(), message.getMessage());
+                broadcast(message);  // pass BroadcastMessage object directly
             }, delay, totalPeriod);
             activeTasks.add(task);
             delay += message.getInterval() * 20L;
         }
     }
 
-    public void broadcast(CommandSender sender, String message) {
+    public void broadcast(BroadcastMessage broadcastMessage) {
+        String message = broadcastMessage.getMessage();
         try {
             for (Player player : Bukkit.getOnlinePlayers()) {
                 // Process PAPI placeholders for each player individually
@@ -83,8 +84,10 @@ public class BroadcastManager {
             }
 
             // Console log using the raw message (no player context for PAPI)
-            String consoleMessage = ColorUtil.stripAllColors(message);
-            plugin.getLogger().info(consoleMessage);
+            if (broadcastMessage.isDisplayInConsole()) {
+                String consoleMessage = ColorUtil.stripAllColors(message);
+                plugin.getLogger().info(consoleMessage);
+            }
 
         } catch (NoSuchMethodError e) {
             // Fall back to traditional Bukkit sendMessage if Adventure API is not available

--- a/src/main/java/com/nonxedy/nonchat/service/ChatService.java
+++ b/src/main/java/com/nonxedy/nonchat/service/ChatService.java
@@ -1,7 +1,6 @@
 package com.nonxedy.nonchat.service;
 
 import com.nonxedy.nonchat.util.core.broadcast.BroadcastMessage;
-import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.nonxedy.nonchat.api.IMessageHandler;

--- a/src/main/java/com/nonxedy/nonchat/service/ChatService.java
+++ b/src/main/java/com/nonxedy/nonchat/service/ChatService.java
@@ -1,5 +1,6 @@
 package com.nonxedy.nonchat.service;
 
+import com.nonxedy.nonchat.util.core.broadcast.BroadcastMessage;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -34,9 +35,9 @@ public class ChatService implements IMessageHandler {
     }
 
     @Override
-    public void handleBroadcast(CommandSender sender, String message) {
+    public void handleBroadcast(BroadcastMessage message) {
         // Broadcasts should always support colors (admin command)
-        broadcastManager.broadcast(sender, message);
+        broadcastManager.broadcast(message);
     }
 
     @Override

--- a/src/main/java/com/nonxedy/nonchat/util/core/broadcast/BroadcastMessage.java
+++ b/src/main/java/com/nonxedy/nonchat/util/core/broadcast/BroadcastMessage.java
@@ -15,4 +15,5 @@ public class BroadcastMessage {
     private boolean enabled;
     private String message;
     private int interval;
+    private boolean displayInConsole;
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -311,6 +311,8 @@ broadcast:
     message: "&#FFAFFBThis message is sent every &#E625DD5&#FFAFFB minutes. You can change the interval in the &#E625DDbroadcast.example.interval&#FFAFFB setting."
     # Interval in seconds for this message to be sent.
     interval: 300
+    # Whether if this message should be displayed in console or not
+    display-in-console: true
 
 # ==================================================
 # CHAT BUBBLE CONFIGURATION


### PR DESCRIPTION
## Changes

Refactored the broadcast pipeline to pass the full `BroadcastMessage` object instead of a raw `String` through `broadcast()`, `handleBroadcast()`, and `IMessageHandler`. This enables per-message configuration rather than relying on caller-level decisions.

### What changed in details
- `IMessageHandler.handleBroadcast()` now takes a `BroadcastMessage` instead of `(CommandSender, String)`
   - CommandSender has never been used even prior to my pull request (#54)
   - Passing the entire BroadCastMessage containing both the string message and the displayInConsole property felt more correct to me.  
- `BroadcastManager.broadcast()` and `ChatService.handleBroadcast()` updated accordingly
- `BroadcastMessage` has a new `displayInConsole` field that controls whether the message is logged to console
- `PluginConfig` reads the new `display-in-console` config key (defaults to `true`)
- `config.yml` exposes the new option with a comment

## Problems to solve

Config updates reset all user-configured broadcast messages, even when using a forced config update (tested with version bump to `1.5.10`). The update correctly adds the missing key `broadcast.example.display-in-console`, but wipes any custom broadcast entries (e.g. `test`) in the process.

**Before update:**
```yaml
  example:
    enabled: true
    message: "&#FFAFFBThis message is sent every &#E625DD5&#FFAFFB minutes. You can change the interval in the &#E625DDbroadcast.example.interval&#FFAFFB setting."
    interval: 300
  test:
    enabled: true
    message: "test"
    interval: 300
```

**After update:**
```yaml
  example:
    enabled: true
    message: "&#FFAFFBThis message is sent every &#E625DD5&#FFAFFB minutes. You can change the interval in the &#E625DDbroadcast.example.interval&#FFAFFB setting."
    interval: 300
    display-in-console: true
```

The `test` broadcast entry is lost and only the `example` entry survives with the new key injected. A workaround has to be introduced in the config update system. 