### PR TITLE
feat(mentions): add config option to allow mentions without '@' prefix

### DIFF
--- a/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
+++ b/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
@@ -606,6 +606,14 @@ public class PluginConfig {
     }
 
     /**
+     * Checks if players can be mentioned by typing their name without the '@' prefix
+     * @return true if bare player names should also trigger mentions
+     */
+    public boolean isMentionWithoutAtEnabled() {
+        return config.getBoolean("mentions.allow-without-at", false);
+    }
+
+    /**
      * Gets private chat sender message format
      * @return Private chat sender format string
      */

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -37,7 +38,7 @@ public class ChatManager {
     private final PluginConfig config;
     private final PluginMessages messages;
     private final ChannelManager channelManager;
-    private final Pattern mentionPattern = Pattern.compile("@(\\w+)");
+    private final Pattern atMentionPattern = Pattern.compile("@(\\w+)");
     private final Map<Player, List<?>> bubbles = new ConcurrentHashMap<>();
     private final Map<Player, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
     private IgnoreCommand ignoreCommand;
@@ -537,10 +538,37 @@ public class ChatManager {
         return false;
     }
 
+    /**
+     * Builds the matcher used to detect mentions in a message.
+     * When mentions are restricted to the '@' prefix, any "@word" counts as a mention
+     * candidate and gets filtered against online players afterward. When bare-name
+     * mentions are allowed, matches are restricted upfront to currently online
+     * player names (with an optional '@' prefix) to avoid flagging ordinary words.
+     */
+    private Matcher getMentionMatcher(String message) {
+        if (!config.isMentionWithoutAtEnabled()) {
+            return atMentionPattern.matcher(message);
+        }
+
+        List<String> onlineNames = Bukkit.getOnlinePlayers().stream()
+                .map(Player::getName)
+                .map(Pattern::quote)
+                .collect(Collectors.toList());
+
+        if (onlineNames.isEmpty()) {
+            return atMentionPattern.matcher(message);
+        }
+
+        Pattern bareNamePattern = Pattern.compile(
+                "@?\\b(" + String.join("|", onlineNames) + ")\\b",
+                Pattern.CASE_INSENSITIVE);
+        return bareNamePattern.matcher(message);
+    }
+
     private void handleMentions(Player sender, String message) {
         // Find all mentions in the message (strip colors first to avoid false matches)
         String messageToCheck = ColorUtil.stripAllColors(message);
-        Matcher mentionMatcher = mentionPattern.matcher(messageToCheck);
+        Matcher mentionMatcher = getMentionMatcher(messageToCheck);
 
         // Collect all the names found into a list and process with Stream API
         List<String> mentionedNames = new ArrayList<>();
@@ -597,7 +625,7 @@ public class ChatManager {
         }
 
         String mentionColor = config.getMentionColor();
-        Matcher mentionMatcher = mentionPattern.matcher(message);
+        Matcher mentionMatcher = getMentionMatcher(message);
 
         // Use StringBuilder for efficient string manipulation
         StringBuilder coloredMessage = new StringBuilder(message.length() + 32); // Add some buffer for color codes

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -39,6 +38,7 @@ public class ChatManager {
     private final PluginMessages messages;
     private final ChannelManager channelManager;
     private final Pattern atMentionPattern = Pattern.compile("@(\\w+)");
+    private final Pattern bareMentionPattern = Pattern.compile("@?\\b(\\w+)\\b");
     private final Map<Player, List<?>> bubbles = new ConcurrentHashMap<>();
     private final Map<Player, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
     private IgnoreCommand ignoreCommand;
@@ -539,30 +539,16 @@ public class ChatManager {
     }
 
     /**
-     * Builds the matcher used to detect mentions in a message.
-     * When mentions are restricted to the '@' prefix, any "@word" counts as a mention
-     * candidate and gets filtered against online players afterward. When bare-name
-     * mentions are allowed, matches are restricted upfront to currently online
-     * player names (with an optional '@' prefix) to avoid flagging ordinary words.
+     * Builds the matcher used to extract mention candidates from a message.
+     * Both patterns are static and compiled once; candidates are always filtered
+     * against currently online players afterward (see {@link #handleMentions} and
+     * {@link #processMentionColoring}), so extraction never needs to depend on
+     * who is online, avoiding per-message pattern compilation and the inconsistent
+     * behavior that came from swapping patterns based on the online player count.
      */
     private Matcher getMentionMatcher(String message) {
-        if (!config.isMentionWithoutAtEnabled()) {
-            return atMentionPattern.matcher(message);
-        }
-
-        List<String> onlineNames = Bukkit.getOnlinePlayers().stream()
-                .map(Player::getName)
-                .map(Pattern::quote)
-                .collect(Collectors.toList());
-
-        if (onlineNames.isEmpty()) {
-            return atMentionPattern.matcher(message);
-        }
-
-        Pattern bareNamePattern = Pattern.compile(
-                "@?\\b(" + String.join("|", onlineNames) + ")\\b",
-                Pattern.CASE_INSENSITIVE);
-        return bareNamePattern.matcher(message);
+        Pattern pattern = config.isMentionWithoutAtEnabled() ? bareMentionPattern : atMentionPattern;
+        return pattern.matcher(message);
     }
 
     private void handleMentions(Player sender, String message) {
@@ -578,9 +564,8 @@ public class ChatManager {
 
         // Process the mentions using Stream API
         mentionedNames.stream()
-                .map(Bukkit::getPlayer)
+                .map(Bukkit::getPlayerExact)
                 .filter(java.util.Objects::nonNull)
-                .filter(Player::isOnline)
                 .forEach(player -> notifyMentionedPlayer(player, sender));
     }
 
@@ -625,6 +610,7 @@ public class ChatManager {
         }
 
         String mentionColor = config.getMentionColor();
+        boolean bareNamesAllowed = config.isMentionWithoutAtEnabled();
         Matcher mentionMatcher = getMentionMatcher(message);
 
         // Use StringBuilder for efficient string manipulation
@@ -632,6 +618,12 @@ public class ChatManager {
         int lastEnd = 0;
 
         while (mentionMatcher.find()) {
+            // The bare-name pattern matches every word in the message, so unlike the
+            // '@'-only pattern it needs an explicit online-player check here to avoid
+            // coloring ordinary words.
+            if (bareNamesAllowed && Bukkit.getPlayerExact(mentionMatcher.group(1)) == null) {
+                continue;
+            }
             // Add text before the mention
             coloredMessage.append(message, lastEnd, mentionMatcher.start());
             // Add the colored mention with reset after it

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -157,6 +157,14 @@ mention-colors:
   color: "&#FFAFFB"
 
 # ==================================================
+# MENTIONS
+# Configure how players can be mentioned in chat.
+# ==================================================
+mentions:
+  # If true, typing an online player's name mentions them even without '@'.
+  allow-without-at: false
+
+# ==================================================
 # CUSTOM CHANNELS
 # Define chat channels with unique settings.
 #


### PR DESCRIPTION
This pull request adds the possibility of mentioning players by just typing their name in chat. Many players in my server (SMP) complained about the @ character being mandatory to ping others, which was causing issues with discord pings as well. Briefly:
- Adds a `mentions.allow-without-at` config option (default `false`, preserving current behavior)
- When enabled, typing an online player's name in chat mentions them even without the `@` prefix, in addition to the existing `@name` syntax.
- Mention detection and mention coloring both respect the new setting; bare-name matches are restricted to currently online player names to avoid false positives on ordinary chat text.