### PR TITLE
feat: integrate bStats anonymous metrics (v3.2.1)

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -70,6 +70,10 @@
       <groupId>dev.faststats.metrics</groupId>
       <artifactId>bukkit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/core/src/main/java/com/nonxedy/nonchat/Nonchat.java
+++ b/core/src/main/java/com/nonxedy/nonchat/Nonchat.java
@@ -43,9 +43,12 @@ import dev.faststats.bukkit.BukkitMetrics;
 import dev.faststats.core.ErrorTracker;
 import dev.faststats.core.data.Metric;
 import lombok.extern.slf4j.Slf4j;
+
+import org.bstats.bukkit.Metrics;
 @Slf4j
 public class Nonchat extends JavaPlugin {
 
+    private static final int BSTATS_PLUGIN_ID = 0; // Update with actual plugin ID from https://bstats.org/what-is-my-plugin-id
     private ChatService chatService;
     private CommandService commandService;
     private ConfigService configService;
@@ -64,6 +67,7 @@ public class Nonchat extends JavaPlugin {
     private PlayerCleanupListener playerCleanupListener;
     private MentionTabCompleteListener mentionTabCompleteListener;
     private IPlatformAdapter platformAdapter;
+    private Metrics bStatsMetrics;
 
     public static final ErrorTracker ERROR_TRACKER = ErrorTracker.contextAware();
     private final BukkitMetrics metrics = BukkitMetrics.factory()
@@ -97,6 +101,7 @@ public class Nonchat extends JavaPlugin {
             registerListeners();
             setupIntegrations();
             metrics.ready();
+            this.bStatsMetrics = new Metrics(this, BSTATS_PLUGIN_ID);
             
             MessageUtil.send(Bukkit.getConsoleSender(), "§d[nonchat] §aplugin enabled");
         } catch (Exception e) {

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -83,6 +83,12 @@
       <artifactId>nonchat-v26_2_R1</artifactId>
       <version>${project.version}</version>
     </dependency>
+
+    <!-- bStats metrics -->
+    <dependency>
+      <groupId>org.bstats</groupId>
+      <artifactId>bstats-bukkit</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -114,6 +120,10 @@
                 <relocation>
                   <pattern>dev.faststats</pattern>
                   <shadedPattern>com.nonxedy.nonchat.libs.faststats</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.bstats</pattern>
+                  <shadedPattern>com.nonxedy.nonchat.libs.bstats</shadedPattern>
                 </relocation>
               </relocations>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
     <faststats.version>0.22.0</faststats.version>
     <junit.version>5.11.4</junit.version>
     <surefire.version>3.5.3</surefire.version>
+    <bstats.version>3.2.1</bstats.version>
   </properties>
 
   <repositories>
@@ -149,6 +150,11 @@
         <artifactId>junit-jupiter</artifactId>
         <version>${junit.version}</version>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.bstats</groupId>
+        <artifactId>bstats-bukkit</artifactId>
+        <version>${bstats.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
## Overview
This PR integrates bStats (v3.2.1) into nonchat to collect anonymous server usage statistics (server software, Minecraft version, Java version, operating system, and player counts).

## Summary of Changes
1. **Parent pom.xml**:
   - Added `<bstats.version>3.2.1</bstats.version>` property.
   - Added `org.bstats:bstats-bukkit` to `<dependencyManagement>`.
2. **Core module (core/pom.xml & Nonchat.java)**:
   - Added `org.bstats:bstats-bukkit` dependency.
   - Initialized `bStatsMetrics = new Metrics(this, BSTATS_PLUGIN_ID)` in `onEnable()`.
   - Set placeholder `BSTATS_PLUGIN_ID = 0`.
3. **Plugin module (plugin/pom.xml)**:
   - Included `org.bstats:bstats-bukkit` in shaded jar dependencies.
   - Added relocation rule in `maven-shade-plugin` (`org.bstats` -> `com.nonxedy.nonchat.libs.bstats`).

## Action Required for Plugin Author
To complete the setup:
1. Register `nonchat` on [bstats.org](https://bstats.org/what-is-my-plugin-id) to obtain your unique numerical **Plugin ID**.
2. Update `BSTATS_PLUGIN_ID = 0;` in `Nonchat.java` with your assigned Plugin ID.