### PR TITLE
Update 1.6.4

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -77,5 +77,7 @@ jobs:
           retention-days: 30
 
       - name: Update dependency graph
-        uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
-        if: github.ref == 'refs/heads/main'
+        uses: advanced-security/maven-dependency-submission-action@b275d12641ac2d2108b2cbb7598b154ad2f2cee8 # v5.0.0
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        with:
+          directory: ${{ github.workspace }}

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-api</artifactId>

--- a/api/src/main/java/com/nonxedy/nonchat/api/Channel.java
+++ b/api/src/main/java/com/nonxedy/nonchat/api/Channel.java
@@ -1,5 +1,8 @@
 package com.nonxedy.nonchat.api;
 
+import java.util.List;
+import java.util.Map;
+
 import org.bukkit.entity.Player;
 
 import net.kyori.adventure.text.Component;
@@ -69,6 +72,18 @@ public interface Channel {
      * @return World name or empty string.
      */
     String getWorld();
+
+    /**
+     * Gets the list of world names for world-specific channels.
+     * @return List of world names.
+     */
+    List<String> getWorlds();
+
+    /**
+     * Gets the map of world-specific radii for this channel.
+     * @return Map of world name to radius.
+     */
+    Map<String, Integer> getWorldRadii();
     
     /**
      * Checks if this is a global channel.

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-core</artifactId>

--- a/core/src/main/java/com/nonxedy/nonchat/Nonchat.java
+++ b/core/src/main/java/com/nonxedy/nonchat/Nonchat.java
@@ -247,7 +247,7 @@ public class Nonchat extends JavaPlugin {
             }
 
             // Register join/quit listener
-            Bukkit.getPluginManager().registerEvents(new JoinQuitListener(configService.getConfig(), chatManager.getChannelManager()), this);
+            Bukkit.getPluginManager().registerEvents(new JoinQuitListener(configService.getConfig(), chatManager.getChannelManager(), chatManager), this);
             this.mentionTabCompleteListener = new MentionTabCompleteListener();
             Bukkit.getPluginManager().registerEvents(mentionTabCompleteListener, this);
             mentionTabCompleteListener.refreshAllPlayers();

--- a/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
+++ b/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
@@ -20,7 +20,7 @@ import com.nonxedy.nonchat.util.special.ping.PingDetector;
 
 import me.clip.placeholderapi.PlaceholderAPI;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.ComponentBuilder;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 /**
@@ -552,8 +552,8 @@ public class BaseChannel implements Channel {
             }
         }
 
-        // Use TextComponent.Builder instead of Component.Builder
-        TextComponent.Builder builder = Component.text();
+        // Use ComponentBuilder<?, ?> to avoid TextComponent.Builder.build() return type incompatibility across Adventure versions
+        ComponentBuilder<?, ?> builder = Component.text();
 
         // Split by [item] and [ping] and process each part
         String[] parts = processedMessage.split("(?i)\\[(item|ping)\\]");

--- a/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
+++ b/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
@@ -55,7 +55,7 @@ public class BaseChannel implements Channel {
                        boolean enabled, HoverTextUtil hoverTextUtil, int cooldown,
                        int minLength, int maxLength) {
         this(id, displayName, format, prefix, sendPermission, receivePermission, radius,
-                (List<String>) null, null, enabled, hoverTextUtil, cooldown, minLength, maxLength, "");
+                new ArrayList<>(), new ConcurrentHashMap<>(), enabled, hoverTextUtil, cooldown, minLength, maxLength, "");
     }
 
     /**
@@ -238,23 +238,20 @@ public class BaseChannel implements Channel {
             String senderWorld = sender.getWorld().getName().toLowerCase();
             String recipientWorld = recipient.getWorld().getName().toLowerCase();
             
-            if (!senderWorld.equals(recipientWorld)) {
-                return false;
-            }
-            if (!worlds.contains(senderWorld)) {
+            if (!worlds.contains(senderWorld) || !worlds.contains(recipientWorld)) {
                 return false;
             }
             
+            int effectiveRadius = radius;
             if (worldRadii.containsKey(senderWorld)) {
-                int worldRadius = worldRadii.get(senderWorld);
-                if (worldRadius < 0) {
-                    return true;
-                }
-                return sender.getLocation().distance(recipient.getLocation()) <= worldRadius;
+                effectiveRadius = worldRadii.get(senderWorld);
             }
             
-            if (radius >= 0) {
-                return sender.getLocation().distance(recipient.getLocation()) <= radius;
+            if (effectiveRadius >= 0) {
+                if (!senderWorld.equals(recipientWorld)) {
+                    return false;
+                }
+                return sender.getLocation().distance(recipient.getLocation()) <= effectiveRadius;
             }
             
             return true;

--- a/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
+++ b/core/src/main/java/com/nonxedy/nonchat/chat/channel/BaseChannel.java
@@ -1,5 +1,9 @@
 package com.nonxedy.nonchat.chat.channel;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -35,6 +39,8 @@ public class BaseChannel implements Channel {
     private final String receivePermission;
     private final int radius;
     private final String world;
+    private final List<String> worlds;
+    private final Map<String, Integer> worldRadii;
     private final int cooldown;
     private final int minLength;
     private final int maxLength;
@@ -49,15 +55,29 @@ public class BaseChannel implements Channel {
                        boolean enabled, HoverTextUtil hoverTextUtil, int cooldown,
                        int minLength, int maxLength) {
         this(id, displayName, format, prefix, sendPermission, receivePermission, radius,
-                "", enabled, hoverTextUtil, cooldown, minLength, maxLength, "");
+                (List<String>) null, null, enabled, hoverTextUtil, cooldown, minLength, maxLength, "");
     }
-    
+
     /**
-     * Creates a new BaseChannel with all properties including world.
+     * Creates a new BaseChannel with all properties
      */
     public BaseChannel(String id, String displayName, String format, String prefix,
                        String sendPermission, String receivePermission, int radius,
-                       String world, boolean enabled, HoverTextUtil hoverTextUtil, int cooldown,
+                       String channelWorld, boolean enabled, HoverTextUtil hoverTextUtil, int cooldown,
+                       int minLength, int maxLength, String channelSwitchMessage) {
+        this(id, displayName, format, prefix, sendPermission, receivePermission, radius,
+                channelWorld != null && !channelWorld.isEmpty() ? List.of(channelWorld.toLowerCase()) : List.of(),
+                new ConcurrentHashMap<>(),
+                enabled, hoverTextUtil, cooldown, minLength, maxLength, channelSwitchMessage);
+    }
+
+    /**
+     * Creates a new BaseChannel with all properties
+     */
+    public BaseChannel(String id, String displayName, String format, String prefix,
+                       String sendPermission, String receivePermission, int radius,
+                       List<String> worlds, Map<String, Integer> worldRadii,
+                       boolean enabled, HoverTextUtil hoverTextUtil, int cooldown,
                        int minLength, int maxLength, String switchMessage) {
         this.id = id;
         this.displayName = displayName;
@@ -82,7 +102,9 @@ public class BaseChannel implements Channel {
         this.sendPermission = sendPermission;
         this.receivePermission = receivePermission;
         this.radius = radius;
-        this.world = world;
+        this.worlds = worlds != null ? new ArrayList<>(worlds) : new ArrayList<>();
+        this.world = !this.worlds.isEmpty() ? this.worlds.get(0) : "";
+        this.worldRadii = worldRadii != null ? new ConcurrentHashMap<>(worldRadii) : new ConcurrentHashMap<>();
         this.enabled = enabled;
         this.hoverTextUtil = hoverTextUtil;
         this.cooldown = cooldown;
@@ -148,8 +170,18 @@ public class BaseChannel implements Channel {
     }
 
     @Override
+    public List<String> getWorlds() {
+        return worlds;
+    }
+
+    @Override
+    public Map<String, Integer> getWorldRadii() {
+        return worldRadii;
+    }
+
+    @Override
     public boolean isWorldSpecific() {
-        return !world.isEmpty();
+        return worlds != null && !worlds.isEmpty();
     }
 
     @Override
@@ -203,8 +235,29 @@ public class BaseChannel implements Channel {
         // Check if this is a world-specific channel
         if (isWorldSpecific()) {
             // For world-specific channels, check if both players are in the specified world
-            return sender.getWorld().getName().equals(world) && 
-                   recipient.getWorld().getName().equals(world);
+            String senderWorld = sender.getWorld().getName().toLowerCase();
+            String recipientWorld = recipient.getWorld().getName().toLowerCase();
+            
+            if (!senderWorld.equals(recipientWorld)) {
+                return false;
+            }
+            if (!worlds.contains(senderWorld)) {
+                return false;
+            }
+            
+            if (worldRadii.containsKey(senderWorld)) {
+                int worldRadius = worldRadii.get(senderWorld);
+                if (worldRadius < 0) {
+                    return true;
+                }
+                return sender.getLocation().distance(recipient.getLocation()) <= worldRadius;
+            }
+            
+            if (radius >= 0) {
+                return sender.getLocation().distance(recipient.getLocation()) <= radius;
+            }
+            
+            return true;
         }
         
         // For numeric radius, make sure they're in the same world

--- a/core/src/main/java/com/nonxedy/nonchat/chat/channel/ChannelManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/chat/channel/ChannelManager.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
@@ -28,8 +29,8 @@ import com.nonxedy.nonchat.util.core.colors.ColorUtil;
  */
 public class ChannelManager {
     private final Map<String, Channel> channels = new ConcurrentHashMap<>();
-    private final Map<Player, Channel> playerChannels = new ConcurrentHashMap<>();
-    private final Map<Player, Long> lastMessageTimes = new ConcurrentHashMap<>();
+    private final Map<UUID, Channel> playerChannels = new ConcurrentHashMap<>();
+    private final Map<UUID, Long> lastMessageTimes = new ConcurrentHashMap<>();
     private String defaultChannelId;
     private final PluginConfig config;
     private final AsyncConfigSaver asyncConfigSaver;
@@ -463,9 +464,10 @@ public class ChannelManager {
 
         // Switch any players using this channel to the default
         Channel defaultChannel = getDefaultChannel();
-        for (Player player : playerChannels.keySet()) {
-            if (playerChannels.get(player).getId().equals(channelId)) {
-                playerChannels.put(player, defaultChannel);
+        for (UUID playerId : playerChannels.keySet()) {
+            Channel activeChannel = playerChannels.get(playerId);
+            if (activeChannel != null && activeChannel.getId().equals(channelId)) {
+                playerChannels.put(playerId, defaultChannel);
             }
         }
 
@@ -753,7 +755,7 @@ public class ChannelManager {
         Channel channel = getChannel(channelId);
 
         if (channel != null && channel.isEnabled()) {
-            playerChannels.put(player, channel);
+            playerChannels.put(player.getUniqueId(), channel);
 
             // Send switch message if configured
             if (channel.hasSwitchMessage()) {
@@ -773,7 +775,7 @@ public class ChannelManager {
      */
     @NotNull
     public Channel getPlayerChannel(Player player) {
-        return playerChannels.getOrDefault(player, getDefaultChannel());
+        return playerChannels.getOrDefault(player.getUniqueId(), getDefaultChannel());
     }
     
     /**
@@ -781,7 +783,7 @@ public class ChannelManager {
      * @param player The player to remove
      */
     public void removePlayerChannel(Player player) {
-        playerChannels.remove(player);
+        playerChannels.remove(player.getUniqueId());
     }
     
     /**
@@ -789,8 +791,8 @@ public class ChannelManager {
      * @param player The player who disconnected
      */
     public void cleanupPlayer(Player player) {
-        playerChannels.remove(player);
-        lastMessageTimes.remove(player);
+        playerChannels.remove(player.getUniqueId());
+        lastMessageTimes.remove(player.getUniqueId());
     }
     
     /**
@@ -798,10 +800,7 @@ public class ChannelManager {
      * @param player The player
      */
     public void recordMessageSent(Player player) {
-        // Clean up old entries to prevent memory leaks
-        lastMessageTimes.entrySet().removeIf(entry -> !entry.getKey().isOnline());
-        
-        lastMessageTimes.put(player, System.currentTimeMillis());
+        lastMessageTimes.put(player.getUniqueId(), System.currentTimeMillis());
     }
     
     /**
@@ -815,7 +814,7 @@ public class ChannelManager {
             return true;
         }
         
-        Long lastMessageTime = lastMessageTimes.get(player);
+        Long lastMessageTime = lastMessageTimes.get(player.getUniqueId());
         if (lastMessageTime == null) {
             return true;
         }
@@ -837,7 +836,7 @@ public class ChannelManager {
             return 0;
         }
         
-        Long lastMessageTime = lastMessageTimes.get(player);
+        Long lastMessageTime = lastMessageTimes.get(player.getUniqueId());
         if (lastMessageTime == null) {
             return 0;
         }

--- a/core/src/main/java/com/nonxedy/nonchat/chat/channel/ChannelManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/chat/channel/ChannelManager.java
@@ -1,13 +1,14 @@
 package com.nonxedy.nonchat.chat.channel;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 
-import com.nonxedy.nonchat.util.core.colors.ColorUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.entity.Player;
@@ -20,6 +21,7 @@ import com.nonxedy.nonchat.api.ChannelAPI;
 import com.nonxedy.nonchat.config.PluginConfig;
 import com.nonxedy.nonchat.util.AsyncConfigSaver;
 import com.nonxedy.nonchat.util.chat.formatting.HoverTextUtil;
+import com.nonxedy.nonchat.util.core.colors.ColorUtil;
 
 /**
  * Manages all chat channels in the nonchat plugin.
@@ -87,25 +89,106 @@ public class ChannelManager {
             
             // Handle radius - can be numeric or "world"
             Object radiusObj = channelSection.get("radius");
+            Object worldsObj = channelSection.get("worlds");
+            if (worldsObj == null) {
+                worldsObj = channelSection.get("world");
+            }
+
             int radius = -1;
-            String world = "";
-            
-            switch (radiusObj) {
-                case String string -> {
-                    String radiusStr = string.toLowerCase().trim();
-                    if (radiusStr.equals("world")) {
-                        radius = -2; // Use -2 to indicate world-specific (not global)
-                        world = "world"; // Default world name, can be configured
-                    } else {
-                        try {
-                            radius = Integer.parseInt(radiusStr);
-                        } catch (NumberFormatException e) {
-                            radius = -1; // Default to global if invalid
+            List<String> worlds = new ArrayList<>();
+            Map<String, Integer> worldRadii = new ConcurrentHashMap<>();
+
+            if (worldsObj != null) {
+                if (worldsObj instanceof List<?> list) {
+                    for (Object item : list) {
+                        if (item != null) {
+                            worlds.add(item.toString().toLowerCase().trim());
+                        }
+                    }
+                } else if (worldsObj instanceof String str) {
+                    for (String w : str.split(",")) {
+                        String trimmed = w.toLowerCase().trim();
+                        if (!trimmed.isEmpty()) {
+                            worlds.add(trimmed);
                         }
                     }
                 }
-                case Integer integer -> radius = integer;
-                default -> {
+            }
+
+            if (radiusObj != null) {
+                if (radiusObj instanceof Integer integer) {
+                    radius = integer;
+                } else if (radiusObj instanceof Long l) {
+                    radius = l.intValue();
+                } else if (radiusObj instanceof String str) {
+                    String s = str.toLowerCase().trim();
+                    if (s.equals("world") || s.equals("world-only") || s.equals("true")) {
+                        radius = -2;
+                        if (worlds.isEmpty()) {
+                            worlds.add("world");
+                        }
+                    } else if (s.contains(",")) {
+                        for (String w : s.split(",")) {
+                            String trimmed = w.toLowerCase().trim();
+                            if (!trimmed.isEmpty()) {
+                                worlds.add(trimmed);
+                            }
+                        }
+                        radius = -2;
+                    } else {
+                        try {
+                            radius = Integer.parseInt(s);
+                        } catch (NumberFormatException e) {
+                            if (!s.isEmpty()) {
+                                worlds.add(s);
+                                radius = -2;
+                            } else {
+                                radius = -1;
+                            }
+                        }
+                    }
+                } else if (radiusObj instanceof List<?> list) {
+                    for (Object item : list) {
+                        if (item != null) {
+                            String itemStr = item.toString().toLowerCase().trim();
+                            if (!itemStr.isEmpty()) {
+                                worlds.add(itemStr);
+                            }
+                        }
+                    }
+                    radius = -2;
+                } else if (radiusObj instanceof ConfigurationSection section) {
+                    radius = -2;
+                    for (String key : section.getKeys(false)) {
+                        String worldName = key.toLowerCase().trim();
+                        Object val = section.get(key);
+                        switch (val) {
+                            case Number num -> {
+                                worldRadii.put(worldName, num.intValue());
+                                if (!worlds.contains(worldName)) {
+                                    worlds.add(worldName);
+                                }
+                            }
+                            case String valStr -> {
+                                try {
+                                    int r = Integer.parseInt(valStr.trim());
+                                    worldRadii.put(worldName, r);
+                                    if (!worlds.contains(worldName)) {
+                                        worlds.add(worldName);
+                                    }
+                                } catch (NumberFormatException e) {
+                                    if (!worlds.contains(worldName)) {
+                                        worlds.add(worldName);
+                                    }
+                                }
+                            }
+                            default -> {
+                                if (!worlds.contains(worldName)) {
+                                    worlds.add(worldName);
+                                }
+                            }
+                        }
+                    }
                 }
             }
             
@@ -117,7 +200,7 @@ public class ChannelManager {
             // Create and register channel
             Channel channel = new BaseChannel(
                 channelId, displayName, format, prefix, sendPermission, receivePermission,
-                radius, world, enabled, hoverTextUtil, cooldown, minLength, maxLength, switchMessage
+                radius, worlds, worldRadii, enabled, hoverTextUtil, cooldown, minLength, maxLength, switchMessage
             );
             
             if (config.isDebug()) {
@@ -196,6 +279,16 @@ public class ChannelManager {
     public Channel createChannel(String channelId, String displayName, String format,
                                 String prefix, String sendPermission, String receivePermission,
                                 int radius, int cooldown, int minLength, int maxLength, String switchMessage) {
+        return createChannel(channelId, displayName, format, prefix, sendPermission, receivePermission, radius, null, null, cooldown, minLength, maxLength, switchMessage);
+    }
+
+    /**
+     * Creates a new channel with the specified properties
+     */
+    public Channel createChannel(String channelId, String displayName, String format,
+                                String prefix, String sendPermission, String receivePermission,
+                                int radius, List<String> worlds, Map<String, Integer> worldRadii,
+                                int cooldown, int minLength, int maxLength, String switchMessage) {
         // Check if channel already exists
         if (channels.containsKey(channelId)) {
             return null;
@@ -237,7 +330,8 @@ public class ChannelManager {
             sendPermission,
             receivePermission,
             radius,
-            "", // Default empty world
+            worlds != null ? worlds : new ArrayList<>(),
+            worldRadii != null ? worldRadii : new ConcurrentHashMap<>(),
             true, // Enabled by default
             config.getHoverTextUtil(),
             cooldown,
@@ -275,6 +369,16 @@ public class ChannelManager {
                                 String prefix, String sendPermission, String receivePermission,
                                 Integer radius, Boolean enabled, Integer cooldown, 
                                 Integer minLength, Integer maxLength, String switchMessage) {
+        return updateChannel(channelId, displayName, format, prefix, sendPermission, receivePermission, radius, null, null, enabled, cooldown, minLength, maxLength, switchMessage);
+    }
+
+    /**
+     * Updates an existing channel with new properties
+     */
+    public boolean updateChannel(String channelId, String displayName, String format,
+                                String prefix, String sendPermission, String receivePermission,
+                                Integer radius, List<String> worlds, Map<String, Integer> worldRadii, Boolean enabled, Integer cooldown, 
+                                Integer minLength, Integer maxLength, String switchMessage) {
         // Get existing channel
         Channel existingChannel = getChannel(channelId);
         if (existingChannel == null) {
@@ -311,7 +415,8 @@ public class ChannelManager {
             sendPermission != null ? sendPermission : existingChannel.getSendPermission(),
             receivePermission != null ? receivePermission : existingChannel.getReceivePermission(),
             radius != null ? radius : existingChannel.getRadius(),
-            existingChannel.getWorld(), // Keep existing world
+            worlds != null ? worlds : existingChannel.getWorlds(),
+            worldRadii != null ? worldRadii : existingChannel.getWorldRadii(),
             enabled != null ? enabled : existingChannel.isEnabled(),
             config.getHoverTextUtil(),
             cooldown != null ? cooldown : existingChannel.getCooldown(),
@@ -402,7 +507,17 @@ public class ChannelManager {
 
         // Save radius - use "world" string for world-specific channels
         if (channel.isWorldSpecific()) {
-            asyncConfigSaver.saveAsync(basePath + "radius", "world");
+            if (channel.getWorldRadii() != null && !channel.getWorldRadii().isEmpty()) {
+                for (Map.Entry<String, Integer> entry : channel.getWorldRadii().entrySet()) {
+                    asyncConfigSaver.saveAsync(basePath + "radius." + entry.getKey(), entry.getValue());
+                }
+            } else if (channel.getWorlds().size() > 1) {
+                asyncConfigSaver.saveAsync(basePath + "radius", channel.getWorlds());
+            } else if (channel.getWorlds().size() == 1) {
+                asyncConfigSaver.saveAsync(basePath + "radius", channel.getWorlds().get(0));
+            } else {
+                asyncConfigSaver.saveAsync(basePath + "radius", "world");
+            }
         } else {
             asyncConfigSaver.saveAsync(basePath + "radius", channel.getRadius());
         }

--- a/core/src/main/java/com/nonxedy/nonchat/command/impl/ChannelCommand.java
+++ b/core/src/main/java/com/nonxedy/nonchat/command/impl/ChannelCommand.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.bukkit.command.Command;
@@ -183,10 +185,20 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
                 .replace("{character}", channel.hasPrefix() ? 
                         channel.getPrefix() : messages.getString("channel-info-none"))));
         
-        MessageUtil.send(player, ColorUtil.parseComponent(messages.getString("channel-info-radius")
-                .replace("{radius}", channel.isGlobal() ? 
-                        messages.getString("channel-info-global") : 
-                        String.valueOf(channel.getRadius()))));
+        String radiusDisplay;
+        if (channel.isGlobal()) {
+            radiusDisplay = messages.getString("channel-info-global");
+        } else if (channel.isWorldSpecific()) {
+            if (channel.getWorldRadii() != null && !channel.getWorldRadii().isEmpty()) {
+                radiusDisplay = channel.getWorldRadii().toString();
+            } else {
+                radiusDisplay = String.join(", ", channel.getWorlds());
+            }
+        } else {
+            radiusDisplay = String.valueOf(channel.getRadius());
+        }
+
+        MessageUtil.send(player, ColorUtil.parseComponent(messages.getString("channel-info-radius").replace("{radius}", radiusDisplay)));
         
         return true;
     }
@@ -227,6 +239,8 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
         String sendPermission = "";
         String receivePermission = "";
         int radius = -1; // Global by default
+        List<String> worlds = new ArrayList<>();
+        Map<String, Integer> worldRadii = new ConcurrentHashMap<>();
         int cooldown = 0;
         int minLength = 0;
         int maxLength = 256;
@@ -246,12 +260,43 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
                 sendPermission = arg.substring(5);
             } else if (arg.startsWith("receive:")) {
                 receivePermission = arg.substring(8);
+            } else if (arg.startsWith("worlds:") || arg.startsWith("world:")) {
+                String worldsStr = arg.substring(arg.indexOf(':') + 1);
+                for (String w : worldsStr.split(",")) {
+                    String trimmed = w.toLowerCase().trim();
+                    if (!trimmed.isEmpty() && !worlds.contains(trimmed)) {
+                        worlds.add(trimmed);
+                    }
+                }
             } else if (arg.startsWith("radius:")) {
-                try {
-                    radius = Integer.parseInt(arg.substring(7));
-                } catch (NumberFormatException e) {
-                    MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("invalid-number")));
-                    return true;
+                String rStr = arg.substring(7).toLowerCase().trim();
+                if (rStr.equals("world") || rStr.equals("world-only")) {
+                    radius = -2;
+                    if (worlds.isEmpty()) {
+                        worlds.add("world");
+                    }
+                } else if (rStr.contains(",")) {
+                    radius = -2;
+                    for (String w : rStr.split(",")) {
+                        String trimmed = w.toLowerCase().trim();
+                        if (!trimmed.isEmpty() && !worlds.contains(trimmed)) {
+                            worlds.add(trimmed);
+                        }
+                    }
+                } else {
+                    try {
+                        radius = Integer.parseInt(rStr);
+                    } catch (NumberFormatException e) {
+                        if (!rStr.isEmpty()) {
+                            radius = -2;
+                            if (!worlds.contains(rStr)) {
+                                worlds.add(rStr);
+                            }
+                        } else {
+                            MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("invalid-number")));
+                            return true;
+                        }
+                    }
                 }
             } else if (arg.startsWith("cooldown:")) {
                 try {
@@ -302,7 +347,7 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
         // Create the channel using ChannelManager directly to support multi-character prefixes
         Channel channel = chatManager.getChannelManager().createChannel(
             channelId, displayName, format, prefix, 
-            sendPermission, receivePermission, radius,
+            sendPermission, receivePermission, radius, worlds, worldRadii,
             cooldown, minLength, maxLength, switchMessage
         );
         
@@ -346,6 +391,8 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
         String sendPermission = null;
         String receivePermission = null;
         Integer radius = null;
+        List<String> worlds = null;
+        Map<String, Integer> worldRadii = null;
         Boolean enabled = null;
         Integer cooldown = null;
         Integer minLength = null;
@@ -367,12 +414,47 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
                 sendPermission = arg.substring(5);
             } else if (arg.startsWith("receive:")) {
                 receivePermission = arg.substring(8);
+            } else if (arg.startsWith("worlds:") || arg.startsWith("world:")) {
+                if (worlds == null) worlds = new ArrayList<>();
+                String worldsStr = arg.substring(arg.indexOf(':') + 1);
+                for (String w : worldsStr.split(",")) {
+                    String trimmed = w.toLowerCase().trim();
+                    if (!trimmed.isEmpty() && !worlds.contains(trimmed)) {
+                        worlds.add(trimmed);
+                    }
+                }
             } else if (arg.startsWith("radius:")) {
-                try {
-                    radius = Integer.valueOf(arg.substring(7));
-                } catch (NumberFormatException e) {
-                    MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("invalid-number")));
-                    return true;
+                String rStr = arg.substring(7).toLowerCase().trim();
+                if (rStr.equals("world") || rStr.equals("world-only")) {
+                    radius = -2;
+                    if (worlds == null) worlds = new ArrayList<>();
+                    if (worlds.isEmpty()) {
+                        worlds.add("world");
+                    }
+                } else if (rStr.contains(",")) {
+                    radius = -2;
+                    if (worlds == null) worlds = new ArrayList<>();
+                    for (String w : rStr.split(",")) {
+                        String trimmed = w.toLowerCase().trim();
+                        if (!trimmed.isEmpty() && !worlds.contains(trimmed)) {
+                            worlds.add(trimmed);
+                        }
+                    }
+                } else {
+                    try {
+                        radius = Integer.valueOf(rStr);
+                    } catch (NumberFormatException e) {
+                        if (!rStr.isEmpty()) {
+                            radius = -2;
+                            if (worlds == null) worlds = new ArrayList<>();
+                            if (!worlds.contains(rStr)) {
+                                worlds.add(rStr);
+                            }
+                        } else {
+                            MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("invalid-number")));
+                            return true;
+                        }
+                    }
                 }
             } else if (arg.startsWith("enabled:")) {
                 enabled = arg.substring(8).equalsIgnoreCase("true");
@@ -425,7 +507,7 @@ public class ChannelCommand implements CommandExecutor, TabCompleter {
         // Update the channel using ChannelManager directly to support multi-character prefixes
         boolean success = chatManager.getChannelManager().updateChannel(
             channelId, displayName, format, prefix,
-            sendPermission, receivePermission, radius, enabled,
+            sendPermission, receivePermission, radius, worlds, worldRadii, enabled,
             cooldown, minLength, maxLength, switchMessage
         );
         

--- a/core/src/main/java/com/nonxedy/nonchat/command/impl/MessageCommand.java
+++ b/core/src/main/java/com/nonxedy/nonchat/command/impl/MessageCommand.java
@@ -118,6 +118,17 @@ public class MessageCommand implements CommandExecutor, TabCompleter {
             return true;
         }
 
+        // Treat players outside the sender's private-message world scope as unavailable.
+        // This deliberately uses the same response as an offline/unknown player so the
+        // restriction does not leak players from other scopes
+        if (sender instanceof Player player && !config.canPrivateMessage(player, target)) {
+            MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("player-not-found")));
+            if (plugin != null) {
+                plugin.logError("Player " + sender.getName() + " tried to message a player outside their world scope.");
+            }
+            return true;
+        }
+
         // Check if target player has ignored the sender
         if (isIgnored(sender, target)) {
             MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("ignored-by-target")));
@@ -284,6 +295,9 @@ public class MessageCommand implements CommandExecutor, TabCompleter {
     
         if (args.length == 1) {
             return Bukkit.getOnlinePlayers().stream()
+                    .filter(player -> !(sender instanceof Player senderPlayer) || senderPlayer.canSee(player))
+                    .filter(player -> !(sender instanceof Player senderPlayer)
+                            || config.canPrivateMessage(senderPlayer, player))
                     .map(Player::getName)
                     .filter(name -> !name.equals(sender.getName()))
                     .filter(name -> name.toLowerCase().startsWith(args[0].toLowerCase()))
@@ -291,7 +305,11 @@ public class MessageCommand implements CommandExecutor, TabCompleter {
         }
     
         if (args.length >= 2) {
-            List<String> mentionSuggestions = MentionCompletionUtil.getMentionSuggestions(sender, args[args.length - 1]);
+            List<String> mentionSuggestions = MentionCompletionUtil.getMentionSuggestions(
+                    sender,
+                    args[args.length - 1],
+                    player -> !(sender instanceof Player senderPlayer)
+                            || config.canPrivateMessage(senderPlayer, player));
             if (!mentionSuggestions.isEmpty()) {
                 return mentionSuggestions;
             }

--- a/core/src/main/java/com/nonxedy/nonchat/command/impl/ReplyCommand.java
+++ b/core/src/main/java/com/nonxedy/nonchat/command/impl/ReplyCommand.java
@@ -65,7 +65,11 @@ public class ReplyCommand implements CommandExecutor, TabCompleter {
         }
 
         if (args.length > 0) {
-            List<String> mentionSuggestions = MentionCompletionUtil.getMentionSuggestions(sender, args[args.length - 1]);
+            List<String> mentionSuggestions = MentionCompletionUtil.getMentionSuggestions(
+                    sender,
+                    args[args.length - 1],
+                    player -> !(sender instanceof Player senderPlayer)
+                            || messageManager.canPrivateMessage(senderPlayer, player));
             if (!mentionSuggestions.isEmpty()) {
                 return mentionSuggestions;
             }

--- a/core/src/main/java/com/nonxedy/nonchat/command/impl/SpyCommand.java
+++ b/core/src/main/java/com/nonxedy/nonchat/command/impl/SpyCommand.java
@@ -121,7 +121,9 @@ public class SpyCommand implements CommandExecutor, TabCompleter {
         // Send formatted message to all spies except sender and target
         for (UUID spyId : spyPlayers) {
             Player spy = plugin.getServer().getPlayer(spyId);
-            if (spy != null && !spy.equals(sender) && !spy.equals(target)) {
+            if (spy != null && !spy.equals(sender) && !spy.equals(target)
+                    && (spy.hasPermission("nonchat.spy.all")
+                        || pluginConfig.canPrivateMessage(spy, sender))) {
                 MessageUtil.send(spy, ColorUtil.parseComponent(spyFormat));
                 plugin.logResponse("Spy " + spy.getName() + " received message: " + spyFormat);
             }

--- a/core/src/main/java/com/nonxedy/nonchat/command/impl/SpyCommand.java
+++ b/core/src/main/java/com/nonxedy/nonchat/command/impl/SpyCommand.java
@@ -4,6 +4,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
@@ -34,7 +35,7 @@ public class SpyCommand implements CommandExecutor, TabCompleter {
     // Plugin configuration reference
     private final PluginConfig pluginConfig;
     // Set to store players who are currently spying
-    private final Set<Player> spyPlayers;
+    private final Set<UUID> spyPlayers;
 
     // Constructor initializes all necessary dependencies
     public SpyCommand(Nonchat plugin, PluginMessages messages, PluginConfig pluginConfig) {
@@ -86,13 +87,13 @@ public class SpyCommand implements CommandExecutor, TabCompleter {
     private void toggleSpyMode(Player player) {
         try {
             // If player is already spying, disable it
-            if (spyPlayers.contains(player)) {
-                spyPlayers.remove(player);
+            if (spyPlayers.contains(player.getUniqueId())) {
+                spyPlayers.remove(player.getUniqueId());
                 MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("spy-mode-disabled")));
                 plugin.logResponse("Spy mode disabled for " + player.getName());
             } else {
                 // If player is not spying, enable it
-                spyPlayers.add(player);
+                spyPlayers.add(player.getUniqueId());
                 MessageUtil.send(player, ColorUtil.parseComponentCached(messages.getString("spy-mode-enabled")));
                 plugin.logResponse("Spy mode enabled for " + player.getName());
             }
@@ -118,8 +119,9 @@ public class SpyCommand implements CommandExecutor, TabCompleter {
                 .replace("{message}", plainMessage);
 
         // Send formatted message to all spies except sender and target
-        for (Player spy : spyPlayers) {
-            if (spy != sender && spy != target && spy.isOnline()) {
+        for (UUID spyId : spyPlayers) {
+            Player spy = plugin.getServer().getPlayer(spyId);
+            if (spy != null && !spy.equals(sender) && !spy.equals(target)) {
                 MessageUtil.send(spy, ColorUtil.parseComponent(spyFormat));
                 plugin.logResponse("Spy " + spy.getName() + " received message: " + spyFormat);
             }
@@ -132,15 +134,26 @@ public class SpyCommand implements CommandExecutor, TabCompleter {
      * @return true if player is spying
      */
     public boolean isSpying(Player player) {
-        return spyPlayers.contains(player);
+        return spyPlayers.contains(player.getUniqueId());
     }
 
     /**
-     * Gets set of all spying players
-     * @return Copy of spy players set
+     * Gets the online players with spy mode enabled
+     *
+     * The internal state is UUID-based; this method keeps the previous
+     * Player-based API for integrations without retaining Player instances
+     *
+     * @return Copy of currently online spying players
      */
     public Set<Player> getSpyPlayers() {
-        return new HashSet<>(spyPlayers);
+        Set<Player> players = new HashSet<>();
+        for (UUID spyId : spyPlayers) {
+            Player player = plugin.getServer().getPlayer(spyId);
+            if (player != null) {
+                players.add(player);
+            }
+        }
+        return players;
     }
 
     /**

--- a/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
+++ b/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
@@ -606,6 +606,14 @@ public class PluginConfig {
     }
 
     /**
+     * Checks if players can be mentioned by typing their name without the '@' prefix
+     * @return true if bare player names should also trigger mentions
+     */
+    public boolean isMentionWithoutAtEnabled() {
+        return config.getBoolean("mentions.allow-without-at", false);
+    }
+
+    /**
      * Gets private chat sender message format
      * @return Private chat sender format string
      */

--- a/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
+++ b/core/src/main/java/com/nonxedy/nonchat/config/PluginConfig.java
@@ -147,6 +147,12 @@ public class PluginConfig {
         ));
         config.set("private-chat.click-actions.enabled", true);
         config.set("private-chat.click-actions.reply-command", "/msg {sender} ");
+        config.set("private-chat.world-separation.enabled", false);
+        config.set("private-chat.world-separation.groups.main", Arrays.asList(
+            "world",
+            "world_nether",
+            "world_the_end"
+        ));
         config.set("spy-format", "§f{sender} §7-> §f{target}§7: §7{message}");
         
         // Chat bubbles configuration
@@ -698,6 +704,65 @@ public class PluginConfig {
     @NotNull
     public String getPrivateChatReplyCommand() {
         return config.getString("private-chat.click-actions.reply-command", "/msg {sender} ");
+    }
+
+    /**
+     * Checks whether private messages are restricted to configured world groups
+     *
+     * @return true when world separation is enabled
+     */
+    public boolean isPrivateChatWorldSeparationEnabled() {
+        return config.getBoolean("private-chat.world-separation.enabled", false);
+    }
+
+    /**
+     * Checks whether two world names belong to the same private-message scope.
+     * Worlds in the same configured group can communicate. Worlds that are not
+     * in a group can communicate only with that exact world
+     *
+     * @param firstWorld first world name
+     * @param secondWorld second world name
+     * @return true when private messaging is allowed between the worlds
+     */
+    public boolean canPrivateMessageBetweenWorlds(String firstWorld, String secondWorld) {
+        if (!isPrivateChatWorldSeparationEnabled()) {
+            return true;
+        }
+        if (firstWorld == null || secondWorld == null) {
+            return false;
+        }
+        if (firstWorld.equalsIgnoreCase(secondWorld)) {
+            return true;
+        }
+
+        ConfigurationSection groups = config.getConfigurationSection("private-chat.world-separation.groups");
+        if (groups == null) {
+            return false;
+        }
+
+        for (String groupName : groups.getKeys(false)) {
+            List<String> worlds = groups.getStringList(groupName);
+            boolean containsFirst = worlds.stream().anyMatch(world -> world.equalsIgnoreCase(firstWorld));
+            boolean containsSecond = worlds.stream().anyMatch(world -> world.equalsIgnoreCase(secondWorld));
+            if (containsFirst && containsSecond) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether two players can exchange private messages under the
+     * configured world-separation policy
+     *
+     * @param sender private-message sender
+     * @param receiver private-message receiver
+     * @return true when the players are in the same private-message scope
+     */
+    public boolean canPrivateMessage(org.bukkit.entity.Player sender, org.bukkit.entity.Player receiver) {
+        return sender != null && receiver != null
+                && canPrivateMessageBetweenWorlds(sender.getWorld().getName(), receiver.getWorld().getName());
     }
 
     /**

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -37,7 +38,7 @@ public class ChatManager {
     private final PluginConfig config;
     private final PluginMessages messages;
     private final ChannelManager channelManager;
-    private final Pattern mentionPattern = Pattern.compile("@(\\w+)");
+    private final Pattern atMentionPattern = Pattern.compile("@(\\w+)");
     private final Map<Player, List<?>> bubbles = new ConcurrentHashMap<>();
     private final Map<Player, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
     private IgnoreCommand ignoreCommand;
@@ -537,10 +538,37 @@ public class ChatManager {
         return false;
     }
 
+    /**
+     * Builds the matcher used to detect mentions in a message.
+     * When mentions are restricted to the '@' prefix, any "@word" counts as a mention
+     * candidate and gets filtered against online players afterward. When bare-name
+     * mentions are allowed, matches are restricted upfront to currently online
+     * player names (with an optional '@' prefix) to avoid flagging ordinary words.
+     */
+    private Matcher getMentionMatcher(String message) {
+        if (!config.isMentionWithoutAtEnabled()) {
+            return atMentionPattern.matcher(message);
+        }
+
+        List<String> onlineNames = Bukkit.getOnlinePlayers().stream()
+                .map(Player::getName)
+                .map(Pattern::quote)
+                .collect(Collectors.toList());
+
+        if (onlineNames.isEmpty()) {
+            return atMentionPattern.matcher(message);
+        }
+
+        Pattern bareNamePattern = Pattern.compile(
+                "@?\\b(" + String.join("|", onlineNames) + ")\\b",
+                Pattern.CASE_INSENSITIVE);
+        return bareNamePattern.matcher(message);
+    }
+
     private void handleMentions(Player sender, String message) {
         // Find all mentions in the message (strip colors first to avoid false matches)
         String messageToCheck = ColorUtil.stripAllColors(message);
-        Matcher mentionMatcher = mentionPattern.matcher(messageToCheck);
+        Matcher mentionMatcher = getMentionMatcher(messageToCheck);
 
         // Collect all the names found into a list and process with Stream API
         List<String> mentionedNames = new ArrayList<>();
@@ -597,7 +625,7 @@ public class ChatManager {
         }
 
         String mentionColor = config.getMentionColor();
-        Matcher mentionMatcher = mentionPattern.matcher(message);
+        Matcher mentionMatcher = getMentionMatcher(message);
 
         // Use StringBuilder for efficient string manipulation
         StringBuilder coloredMessage = new StringBuilder(message.length() + 32); // Add some buffer for color codes

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -7,7 +7,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -39,6 +38,7 @@ public class ChatManager {
     private final PluginMessages messages;
     private final ChannelManager channelManager;
     private final Pattern atMentionPattern = Pattern.compile("@(\\w+)");
+    private final Pattern bareMentionPattern = Pattern.compile("@?\\b(\\w+)\\b");
     private final Map<Player, List<?>> bubbles = new ConcurrentHashMap<>();
     private final Map<Player, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
     private IgnoreCommand ignoreCommand;
@@ -539,30 +539,16 @@ public class ChatManager {
     }
 
     /**
-     * Builds the matcher used to detect mentions in a message.
-     * When mentions are restricted to the '@' prefix, any "@word" counts as a mention
-     * candidate and gets filtered against online players afterward. When bare-name
-     * mentions are allowed, matches are restricted upfront to currently online
-     * player names (with an optional '@' prefix) to avoid flagging ordinary words.
+     * Builds the matcher used to extract mention candidates from a message.
+     * Both patterns are static and compiled once; candidates are always filtered
+     * against currently online players afterward (see {@link #handleMentions} and
+     * {@link #processMentionColoring}), so extraction never needs to depend on
+     * who is online, avoiding per-message pattern compilation and the inconsistent
+     * behavior that came from swapping patterns based on the online player count.
      */
     private Matcher getMentionMatcher(String message) {
-        if (!config.isMentionWithoutAtEnabled()) {
-            return atMentionPattern.matcher(message);
-        }
-
-        List<String> onlineNames = Bukkit.getOnlinePlayers().stream()
-                .map(Player::getName)
-                .map(Pattern::quote)
-                .collect(Collectors.toList());
-
-        if (onlineNames.isEmpty()) {
-            return atMentionPattern.matcher(message);
-        }
-
-        Pattern bareNamePattern = Pattern.compile(
-                "@?\\b(" + String.join("|", onlineNames) + ")\\b",
-                Pattern.CASE_INSENSITIVE);
-        return bareNamePattern.matcher(message);
+        Pattern pattern = config.isMentionWithoutAtEnabled() ? bareMentionPattern : atMentionPattern;
+        return pattern.matcher(message);
     }
 
     private void handleMentions(Player sender, String message) {
@@ -578,9 +564,8 @@ public class ChatManager {
 
         // Process the mentions using Stream API
         mentionedNames.stream()
-                .map(Bukkit::getPlayer)
+                .map(Bukkit::getPlayerExact)
                 .filter(java.util.Objects::nonNull)
-                .filter(Player::isOnline)
                 .forEach(player -> notifyMentionedPlayer(player, sender));
     }
 
@@ -625,6 +610,7 @@ public class ChatManager {
         }
 
         String mentionColor = config.getMentionColor();
+        boolean bareNamesAllowed = config.isMentionWithoutAtEnabled();
         Matcher mentionMatcher = getMentionMatcher(message);
 
         // Use StringBuilder for efficient string manipulation
@@ -632,6 +618,12 @@ public class ChatManager {
         int lastEnd = 0;
 
         while (mentionMatcher.find()) {
+            // The bare-name pattern matches every word in the message, so unlike the
+            // '@'-only pattern it needs an explicit online-player check here to avoid
+            // coloring ordinary words.
+            if (bareNamesAllowed && Bukkit.getPlayerExact(mentionMatcher.group(1)) == null) {
+                continue;
+            }
             // Add text before the mention
             coloredMessage.append(message, lastEnd, mentionMatcher.start());
             // Add the colored mention with reset after it

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -643,9 +643,7 @@ public class ChatManager {
     private boolean broadcastMessage(Player sender, Component message, Channel channel, String originalMessage) {
         // For console, create a simple message without our color modifications to avoid
         // &f appearing
-        String consoleFormat = channel.getFormat().replace("{message}", originalMessage);
-
-        // Apply PlaceholderAPI for console
+        String consoleFormat = channel.getFormat();
         if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             try {
                 consoleFormat = PlaceholderAPI.setPlaceholders(sender, consoleFormat);
@@ -653,6 +651,7 @@ public class ChatManager {
                 plugin.logError("Error processing format placeholders for console: " + e.getMessage());
             }
         }
+        consoleFormat = consoleFormat.replace("{message}", originalMessage);
 
         // Send to console with processed format
         MessageUtil.send(Bukkit.getConsoleSender(), ColorUtil.parseComponent(consoleFormat));

--- a/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/ChatManager.java
@@ -3,6 +3,7 @@ package com.nonxedy.nonchat.core;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
@@ -39,8 +40,8 @@ public class ChatManager {
     private final ChannelManager channelManager;
     private final Pattern atMentionPattern = Pattern.compile("@(\\w+)");
     private final Pattern bareMentionPattern = Pattern.compile("@?\\b(\\w+)\\b");
-    private final Map<Player, List<?>> bubbles = new ConcurrentHashMap<>();
-    private final Map<Player, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
+    private final Map<UUID, List<?>> bubbles = new ConcurrentHashMap<>();
+    private final Map<UUID, ReentrantLock> playerLocks = new ConcurrentHashMap<>();
     private IgnoreCommand ignoreCommand;
     private final AdDetector adDetector;
     private final SpamDetector spamDetector;
@@ -72,7 +73,7 @@ public class ChatManager {
         plugin.logChatMessage("Incoming: Player=" + player.getName() + " Message=\"" + messageContent + "\"");
 
         // Get or create player-specific lock
-        ReentrantLock lock = playerLocks.computeIfAbsent(player, p -> new ReentrantLock());
+        ReentrantLock lock = playerLocks.computeIfAbsent(player.getUniqueId(), p -> new ReentrantLock());
         lock.lock();
         try {
             ChatProcessingContext context = new ChatProcessingContext(player, messageContent);
@@ -122,7 +123,7 @@ public class ChatManager {
 
             // Clean up lock if player is offline
             if (!player.isOnline()) {
-                playerLocks.remove(player);
+                playerLocks.remove(player.getUniqueId());
             }
         }
     }
@@ -423,29 +424,20 @@ public class ChatManager {
     private void updateBubbles() {
         try {
             // Update bubble positions for online players
-            bubbles.entrySet().stream()
-                    .filter(entry -> entry.getKey().isOnline() && !entry.getValue().isEmpty())
-                    .forEach(entry -> {
-                        try {
-                            Player player = entry.getKey();
-                            Location newLoc = player.getLocation().add(0, config.getChatBubblesHeight(), 0);
-                            plugin.getPlatformAdapter().updateBubblesLocation(entry.getValue(), newLoc);
-                        } catch (Exception e) {
-                            plugin.logError("Error updating bubbles for player " + entry.getKey().getName() + ": "
-                                    + e.getMessage());
-                        }
-                    });
-
-            // Clean up bubbles for offline players
             bubbles.entrySet().removeIf(entry -> {
                 try {
-                    if (!entry.getKey().isOnline()) {
+                    Player player = Bukkit.getPlayer(entry.getKey());
+                    if (player == null || !player.isOnline()) {
                         plugin.getPlatformAdapter().removeBubbles(entry.getValue());
                         return true;
                     }
+                    if (!entry.getValue().isEmpty()) {
+                        Location newLoc = player.getLocation().add(0, config.getChatBubblesHeight(), 0);
+                        plugin.getPlatformAdapter().updateBubblesLocation(entry.getValue(), newLoc);
+                    }
                 } catch (Exception e) {
-                    plugin.logError("Error cleaning up bubbles for offline player: " + e.getMessage());
-                    return true; // Remove entry on error
+                    plugin.logError("Error updating chat bubbles for " + entry.getKey() + ": " + e.getMessage());
+                    return true;
                 }
                 return false;
             });
@@ -468,7 +460,7 @@ public class ChatManager {
 
             // Only add bubbles if they were successfully created
             if (playerBubbles != null && !playerBubbles.isEmpty()) {
-                bubbles.put(player, playerBubbles);
+                bubbles.put(player.getUniqueId(), playerBubbles);
 
                 try {
                     Bukkit.getScheduler().runTaskLater(plugin, () -> {
@@ -504,7 +496,7 @@ public class ChatManager {
 
     private void removeBubble(Player player) {
         try {
-            List<?> playerBubbles = bubbles.remove(player);
+            List<?> playerBubbles = bubbles.remove(player.getUniqueId());
             if (playerBubbles != null) {
                 plugin.getPlatformAdapter().removeBubbles(playerBubbles);
             }
@@ -512,7 +504,7 @@ public class ChatManager {
             plugin.logError("Error removing bubbles for player " + player.getName() + ": " + e.getMessage());
             // Try to clean up the map entry even if removal fails
             try {
-                bubbles.remove(player);
+                bubbles.remove(player.getUniqueId());
             } catch (Exception cleanupError) {
                 plugin.logError("Error cleaning up bubble map for player " + player.getName() + ": "
                         + cleanupError.getMessage());
@@ -828,6 +820,12 @@ public class ChatManager {
 
     public ChannelManager getChannelManager() {
         return channelManager;
+    }
+
+    // Removes player-bound runtime state immediately when a player disconnects
+    public void cleanupPlayer(Player player) {
+        playerLocks.remove(player.getUniqueId());
+        removeBubble(player);
     }
 
     /**

--- a/core/src/main/java/com/nonxedy/nonchat/core/MessageManager.java
+++ b/core/src/main/java/com/nonxedy/nonchat/core/MessageManager.java
@@ -65,6 +65,22 @@ public class MessageManager {
     }
 
     public void sendPrivateMessage(Player sender, Player receiver, String message) {
+        // Check if receiver is online and available to receive the message
+        if (receiver == null || !receiver.isOnline()) {
+            // Only show notification if enabled in config
+            if (config.isUndeliveredMessageNotificationEnabled()) {
+                MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("message-not-delivered")));
+            }
+            return;
+        }
+
+        // Re-check the world scope at delivery time. This also protects /reply
+        // when either player has moved to a different world since the last PM
+        if (!config.canPrivateMessage(sender, receiver)) {
+            MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("player-not-found")));
+            return;
+        }
+
         if (ignoreCommand != null && ignoreCommand.isIgnoring(receiver, sender)) {
             MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("ignored-by-target")));
             return;
@@ -73,15 +89,6 @@ public class MessageManager {
         if (ignoreCommand != null && ignoreCommand.isIgnoring(sender, receiver)) {
             MessageUtil.send(sender, ColorUtil.parseComponent(messages.getString("you-are-ignoring-player")
                     .replace("{player}", receiver.getName())));
-            return;
-        }
-
-        // Check if receiver is online and available to receive the message
-        if (receiver == null || !receiver.isOnline()) {
-            // Only show notification if enabled in config
-            if (config.isUndeliveredMessageNotificationEnabled()) {
-                MessageUtil.send(sender, ColorUtil.parseComponentCached(messages.getString("message-not-delivered")));
-            }
             return;
         }
 
@@ -120,6 +127,17 @@ public class MessageManager {
     public Player getLastMessageSender(Player player) {
         UUID lastSenderUUID = lastMessageSender.get(player.getUniqueId());
         return lastSenderUUID != null ? Bukkit.getPlayer(lastSenderUUID) : null;
+    }
+
+    /**
+     * Checks whether a player is in the sender's configured private-message scope.
+     *
+     * @param sender private-message sender
+     * @param receiver candidate receiver
+     * @return true when private messaging is permitted between their worlds
+     */
+    public boolean canPrivateMessage(Player sender, Player receiver) {
+        return config.canPrivateMessage(sender, receiver);
     }
 
     public void clearLastMessageSender(Player player) {

--- a/core/src/main/java/com/nonxedy/nonchat/listener/DamageTrackingListener.java
+++ b/core/src/main/java/com/nonxedy/nonchat/listener/DamageTrackingListener.java
@@ -1,9 +1,5 @@
 package com.nonxedy.nonchat.listener;
 
-import com.nonxedy.nonchat.config.DeathConfig;
-import com.nonxedy.nonchat.core.IndirectDeathTracker;
-import com.nonxedy.nonchat.util.core.debugging.Debugger;
-import com.nonxedy.nonchat.util.death.DamageType;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
@@ -14,6 +10,11 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.projectiles.ProjectileSource;
+
+import com.nonxedy.nonchat.config.DeathConfig;
+import com.nonxedy.nonchat.core.IndirectDeathTracker;
+import com.nonxedy.nonchat.util.core.debugging.Debugger;
+import com.nonxedy.nonchat.util.death.DamageType;
 
 /**
  * Listens to damage events and records them for indirect death tracking.
@@ -60,7 +61,7 @@ public class DamageTrackingListener implements Listener {
         
         double damageInHearts = event.getFinalDamage() / 2.0;
         if (damageInHearts < minimumDamage) {
-            if (deathConfig.isDebugEnabled()) {
+            if (deathConfig.isDebugEnabled() && debugger != null) {
                 debugger.debug("DamageTrackingListener", String.format(
                     "Damage below threshold: %s -> %s (%.1f hearts < %.1f hearts minimum)",
                     event.getDamager().getType().name(),
@@ -74,7 +75,7 @@ public class DamageTrackingListener implements Listener {
         
         Player damager = extractDamager(event.getDamager());
         if (damager == null) {
-            if (deathConfig.isDebugEnabled()) {
+            if (deathConfig.isDebugEnabled() && debugger != null) {
                 debugger.debug("DamageTrackingListener", String.format(
                     "No player damager found for damage to %s (damager type: %s)",
                     victim.getName(),
@@ -85,7 +86,7 @@ public class DamageTrackingListener implements Listener {
         }
         
         if (victim.getUniqueId().equals(damager.getUniqueId())) {
-            if (deathConfig.isDebugEnabled()) {
+            if (deathConfig.isDebugEnabled() && debugger != null) {
                 debugger.debug("DamageTrackingListener", String.format(
                     "Ignoring self-damage: %s",
                     victim.getName()
@@ -97,7 +98,7 @@ public class DamageTrackingListener implements Listener {
         DamageType damageType = classifyDamageType(event);
         tracker.recordDamage(victim, damager, damageType);
         
-        if (deathConfig.isDebugEnabled()) {
+        if (deathConfig.isDebugEnabled() && debugger != null) {
             debugger.info("DamageTrackingListener", String.format(
                 "Recorded %s damage: %s -> %s (%.1f hearts, cause: %s)",
                 damageType.name(),
@@ -129,7 +130,7 @@ public class DamageTrackingListener implements Listener {
             Projectile projectile = (Projectile) damager;
             ProjectileSource shooter = projectile.getShooter();
             if (shooter == null) {
-                if (deathConfig.isDebugEnabled()) {
+                if (deathConfig.isDebugEnabled() && debugger != null) {
                     debugger.debug("DamageTrackingListener", "Projectile has null shooter");
                 }
                 return null;

--- a/core/src/main/java/com/nonxedy/nonchat/listener/JoinQuitListener.java
+++ b/core/src/main/java/com/nonxedy/nonchat/listener/JoinQuitListener.java
@@ -1,11 +1,13 @@
 package com.nonxedy.nonchat.listener;
 
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import java.util.logging.Level;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Sound;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -44,17 +46,29 @@ public class JoinQuitListener implements Listener {
      * @return The cleaned sound name in proper format (lowercase with dots)
      */
     private String cleanSoundName(String soundName) {
-        if (soundName == null) {
+        if (soundName == null || soundName.trim().isEmpty()) {
             return "entity.experience_orb.pickup"; // fallback sound
         }
-        
+
         // Remove "minecraft:" prefix if present
-        String cleaned = soundName.replace("minecraft:", "");
-        
-        // Convert from old format (ENTITY_EXPERIENCE_ORB_PICKUP) to new format (entity.experience_orb.pickup)
-        cleaned = cleaned.toLowerCase().replace('_', '.');
-        
-        return cleaned;
+        String cleaned = soundName.trim();
+        if (cleaned.toLowerCase(Locale.ROOT).startsWith("minecraft:")) {
+            cleaned = cleaned.substring("minecraft:".length());
+        }
+
+        // Already in resource-key format (e.g. "entity.experience_orb.pickup")
+        if (cleaned.contains(".")) {
+            return cleaned.toLowerCase(Locale.ROOT);
+        }
+
+        try {
+            Sound sound = Sound.valueOf(cleaned.toUpperCase(Locale.ROOT).replace(' ', '_'));
+            return sound.getKey().getKey();
+        } catch (IllegalArgumentException e) {
+            Bukkit.getLogger().log(Level.WARNING,
+                "Unknown sound name in config: {0} - falling back to naive conversion", soundName);
+            return cleaned.toLowerCase(Locale.ROOT).replace('_', '.');
+        }
     }
     
     /**

--- a/core/src/main/java/com/nonxedy/nonchat/listener/JoinQuitListener.java
+++ b/core/src/main/java/com/nonxedy/nonchat/listener/JoinQuitListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 
 import com.nonxedy.nonchat.chat.channel.ChannelManager;
 import com.nonxedy.nonchat.config.PluginConfig;
+import com.nonxedy.nonchat.core.ChatManager;
 import com.nonxedy.nonchat.util.core.colors.ColorUtil;
 import com.nonxedy.nonchat.util.core.messages.MessageUtil;
 
@@ -28,11 +29,13 @@ public class JoinQuitListener implements Listener {
     
     private final PluginConfig config;
     private final ChannelManager channelManager;
+    private final ChatManager chatManager;
     private final Map<UUID, Boolean> firstJoinCache = new HashMap<>();
     
-    public JoinQuitListener(PluginConfig config, ChannelManager channelManager) {
+    public JoinQuitListener(PluginConfig config, ChannelManager channelManager, ChatManager chatManager) {
         this.config = config;
         this.channelManager = channelManager;
+        this.chatManager = chatManager;
     }
 
     /**
@@ -118,6 +121,9 @@ public class JoinQuitListener implements Listener {
         // Clean up player data from ChannelManager to prevent memory leaks
         if (channelManager != null) {
             channelManager.cleanupPlayer(player);
+        }
+        if (chatManager != null) {
+            chatManager.cleanupPlayer(player);
         }
         
         if (!config.isQuitMessageEnabled()) {

--- a/core/src/main/java/com/nonxedy/nonchat/placeholders/impl/ConfigurablePlaceholder.java
+++ b/core/src/main/java/com/nonxedy/nonchat/placeholders/impl/ConfigurablePlaceholder.java
@@ -197,7 +197,9 @@ public class ConfigurablePlaceholder implements InteractivePlaceholder {
     }
 
     private Component processPlaceholders(Player player, String text) {
-        String processed = text;
+        // PAPI may evaluate only administrator-configured templates. Item names,
+        // lore and player-derived values are added after this step
+        String processed = applyPlaceholderApi(player, text);
 
         // Replace basic placeholders
         processed = processed.replace("{player}", player.getName());
@@ -223,17 +225,19 @@ public class ConfigurablePlaceholder implements InteractivePlaceholder {
             processed = processed.replace("{ping_quality}", quality);
         }
 
-        // Process PlaceholderAPI placeholders if available
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
-            try {
-                processed = PlaceholderAPI.setPlaceholders(player, processed);
-            } catch (Exception e) {
-                // Ignore PlaceholderAPI errors
-            }
-        }
-
         // Convert color codes
         return ColorUtil.parseComponent(processed);
+    }
+
+    private String applyPlaceholderApi(Player player, String template) {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") == null) {
+            return template;
+        }
+        try {
+            return PlaceholderAPI.setPlaceholders(player, template);
+        } catch (Exception ignored) {
+            return template;
+        }
     }
 
     private String processItemPlaceholders(String text, Player player, ItemStack item) {
@@ -313,7 +317,8 @@ public class ConfigurablePlaceholder implements InteractivePlaceholder {
     }
 
     private String processPlaceholdersAsString(Player player, String text) {
-        String processed = text;
+        // Keep click-action values subject to the same safe ordering
+        String processed = applyPlaceholderApi(player, text);
 
         // Replace basic placeholders
         processed = processed.replace("{player}", player.getName());
@@ -337,15 +342,6 @@ public class ConfigurablePlaceholder implements InteractivePlaceholder {
             processed = processed.replace("{ping}", String.valueOf(ping));
             String quality = ping < 100 ? "Excellent" : ping < 300 ? "Good" : "Poor";
             processed = processed.replace("{ping_quality}", quality);
-        }
-
-        // Process PlaceholderAPI placeholders if available
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
-            try {
-                processed = PlaceholderAPI.setPlaceholders(player, processed);
-            } catch (Exception e) {
-                // Ignore PlaceholderAPI errors
-            }
         }
 
         // Return processed string (don't convert to Component)

--- a/core/src/main/java/com/nonxedy/nonchat/util/chat/MentionCompletionUtil.java
+++ b/core/src/main/java/com/nonxedy/nonchat/util/chat/MentionCompletionUtil.java
@@ -3,6 +3,7 @@ package com.nonxedy.nonchat.util.chat;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Predicate;
 
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
@@ -23,6 +24,19 @@ public final class MentionCompletionUtil {
      * @return visible online player names prefixed with @, or an empty list when the token is not a mention
      */
     public static List<String> getMentionSuggestions(CommandSender sender, String lastToken) {
+        return getMentionSuggestions(sender, lastToken, player -> true);
+    }
+
+    /**
+     * Returns @mention suggestions restricted by an additional player filter
+     *
+     * @param sender sender requesting completions
+     * @param lastToken current token/argument being completed
+     * @param playerFilter additional visibility/scope filter
+     * @return matching visible online player names prefixed with @
+     */
+    public static List<String> getMentionSuggestions(CommandSender sender, String lastToken,
+                                                       Predicate<Player> playerFilter) {
         if (lastToken == null || !lastToken.startsWith("@")) {
             return List.of();
         }
@@ -32,6 +46,10 @@ public final class MentionCompletionUtil {
 
         for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
             if (sender instanceof Player player && !player.canSee(onlinePlayer)) {
+                continue;
+            }
+
+            if (!playerFilter.test(onlinePlayer)) {
                 continue;
             }
 

--- a/core/src/main/java/com/nonxedy/nonchat/util/chat/formatting/HoverTextUtil.java
+++ b/core/src/main/java/com/nonxedy/nonchat/util/chat/formatting/HoverTextUtil.java
@@ -111,20 +111,9 @@ public class HoverTextUtil {
     private String processHoverLine(String line, Player player) {
         if (line == null) return "";
         
-        // Get integration data
-        String prefix = IntegrationUtil.getPlayerPrefix(player);
-        String balance = IntegrationUtil.getBalance(player);
-        String playtime = IntegrationUtil.getPlayTime(player);
-        
-        // Replace basic placeholders
-        String processed = line
-            .replace("{player}", player.getName())
-            .replace("{level}", String.valueOf(player.getLevel()))
-            .replace("{prefix}", prefix != null ? prefix : "")
-            .replace("{playtime}", playtime != null ? playtime : "0h")
-            .replace("{balance}", balance != null ? balance : "0");
-    
-        // Process PlaceholderAPI if available
+        // Resolve PAPI in the administrator-configured hover template before
+        // adding player or integration values
+        String processed = line;
         if (usePlaceholderAPI) {
             try {
                 processed = PlaceholderAPI.setPlaceholders(player, processed);
@@ -132,6 +121,19 @@ public class HoverTextUtil {
                 Bukkit.getLogger().log(Level.WARNING, "Error processing placeholder in hover text: {0}", e.getMessage());
             }
         }
+
+        // Get integration data
+        String prefix = IntegrationUtil.getPlayerPrefix(player);
+        String balance = IntegrationUtil.getBalance(player);
+        String playtime = IntegrationUtil.getPlayTime(player);
+        
+        // Replace basic placeholders
+        processed = processed
+            .replace("{player}", player.getName())
+            .replace("{level}", String.valueOf(player.getLevel()))
+            .replace("{prefix}", prefix != null ? prefix : "")
+            .replace("{playtime}", playtime != null ? playtime : "0h")
+            .replace("{balance}", balance != null ? balance : "0");
     
         return processed;
     }

--- a/core/src/main/java/com/nonxedy/nonchat/util/core/updates/UpdateChecker.java
+++ b/core/src/main/java/com/nonxedy/nonchat/util/core/updates/UpdateChecker.java
@@ -157,10 +157,9 @@ public final class UpdateChecker implements Listener {
         try {
             MessageUtil.send(player, ColorUtil.parseComponent("&#FFAFFB[nonchat] &#ffffff A new version is available: &#FFAFFB" + latestVersion));
         
-            Component downloadMessage = Component.text()
+            Component downloadMessage = Component.empty()
                 .append(ColorUtil.parseComponent("&#FFAFFB[nonchat] &#ffffffDownload: "))
-                .append(LinkDetector.makeLinksClickable(downloadUrl))
-                .build();
+                .append(LinkDetector.makeLinksClickable(downloadUrl));
         
             MessageUtil.send(player, downloadMessage);
             

--- a/core/src/main/java/com/nonxedy/nonchat/util/special/ping/PingDetector.java
+++ b/core/src/main/java/com/nonxedy/nonchat/util/special/ping/PingDetector.java
@@ -10,7 +10,7 @@ import org.bukkit.plugin.Plugin;
 import com.nonxedy.nonchat.Nonchat;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.TextComponent;
+import net.kyori.adventure.text.ComponentBuilder;
 import net.kyori.adventure.text.format.NamedTextColor;
 
 /**
@@ -47,7 +47,7 @@ public class PingDetector {
             return Component.text(text);
         }
         
-        TextComponent.Builder builder = Component.text().content("");
+        ComponentBuilder<?, ?> builder = Component.text().content("");
         Matcher matcher = PING_PATTERN.matcher(text);
         int lastEnd = 0;
         boolean foundPing = false;

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-plugin</artifactId>
@@ -87,7 +87,40 @@
 
   <build>
     <finalName>nonchat-${project.version}</finalName>
+
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>plugin.yml</include>
+          <include>config.yml</include>
+          <include>langs/*.yml</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>false</filtering>
+        <excludes>
+          <exclude>plugin.yml</exclude>
+          <exclude>config.yml</exclude>
+          <exclude>langs/*.yml</exclude>
+        </excludes>
+      </resource>
+    </resources>
+
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <version>3.5.0</version>
+        <configuration>
+          <useDefaultDelimiters>false</useDefaultDelimiters>
+          <delimiters>
+            <delimiter>${*}</delimiter>
+          </delimiters>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -157,6 +157,14 @@ mention-colors:
   color: "&#FFAFFB"
 
 # ==================================================
+# MENTIONS
+# Configure how players can be mentioned in chat.
+# ==================================================
+mentions:
+  # If true, typing an online player's name mentions them even without '@'.
+  allow-without-at: false
+
+# ==================================================
 # CUSTOM CHANNELS
 # Define chat channels with unique settings.
 #

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -3,7 +3,7 @@
 # Plugin created by utophii (@utophii).
 # Published on github https://github.com/utophii/nonchat
 # Published on modrinth https://modrinth.com/plugin/nonchat
-# Version of the plugin: 1.6.3
+# Version of the plugin: ${project.version}
 #
 # - LuckPerms support.
 # - Vault support.

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -304,6 +304,20 @@ private-chat:
     # Command executed when clicking to reply. Use {sender} as a placeholder.
     reply-command: "/msg {sender} "
 
+  # Optionally restrict private messages and their player tab-completions by world.
+  world-separation:
+    enabled: false
+    # Worlds in the same group can message one another. Worlds not listed in a
+    # group are isolated to their exact world. World names are case-insensitive.
+    groups:
+      main:
+        - world
+        - world_nether
+        - world_the_end
+      # Example: a player in world1 can only message another player in world1.
+      # world1:
+      #   - world1
+
 # ==================================================
 # SPY COMMAND
 # ==================================================

--- a/plugin/src/main/resources/config.yml
+++ b/plugin/src/main/resources/config.yml
@@ -175,7 +175,11 @@ mentions:
 #   enabled: (true/false) - Enable or disable the channel.
 #   display-name: ("Name") - Name shown in messages.
 #   format: ("text {placeholders}") - Message format (must include {message}).
-#   radius: (number or 'world') - Chat radius in blocks. -1 for global, 'world' for world-only.
+#   radius: (number, 'world', list of worlds, or map) - Chat radius in blocks. -1 for global, 'world' or list/map of worlds for world-only/multi-world.
+#   For multi-world chat radius use this:
+#     radius:
+#       world1: number
+#       world2: number
 #   character: ('X') - Prefix character to talk in this channel.
 #   send-permission: ("permission.node") - Permission required to send messages.
 #   receive-permission: ("permission.node") - Permission required to receive messages.

--- a/plugin/src/main/resources/langs/messages_en.yml
+++ b/plugin/src/main/resources/langs/messages_en.yml
@@ -3,7 +3,7 @@
 # Plugin created by utophii (@utophii).
 # Published on github https://github.com/utophii/nonchat
 # Published on modrinth https://modrinth.com/plugin/nonchat
-# Version of the plugin: 1.6.3
+# Version of the plugin: ${project.version}
 #
 # - LuckPerms support.
 # - Vault support.

--- a/plugin/src/main/resources/langs/messages_es.yml
+++ b/plugin/src/main/resources/langs/messages_es.yml
@@ -3,7 +3,7 @@
 # Plugin creado por utophii (@utophii).
 # Publicado en github https://github.com/utophii/nonchat
 # Publicado en modrinth https://modrinth.com/plugin/nonchat
-# Versión del plugin: 1.6.3
+# Versión del plugin: ${project.version}
 #
 # - Soporte para LuckPerms.
 # - Soporte para Vault.

--- a/plugin/src/main/resources/langs/messages_ru.yml
+++ b/plugin/src/main/resources/langs/messages_ru.yml
@@ -3,7 +3,7 @@
 # Plugin created by utophii (@utophii).
 # Published on github https://github.com/utophii/nonchat
 # Published on modrinth https://modrinth.com/plugin/nonchat
-# Version of the plugin: 1.6.3
+# Version of the plugin: ${project.version}
 #
 # - LuckPerms support.
 # - Vault support.

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: nonchat
 author: utophii
 main: com.nonxedy.nonchat.Nonchat
 description: The best chat plugin for 1.16.5-26.2
-version: 1.6.3
+version: ${project.version}
 prefix: nonchat
 api-version: 1.16
 load: STARTUP

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>com.nonxedy.nonchat</groupId>
   <artifactId>nonchat-parent</artifactId>
-  <version>1.6.3</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
 
   <name>nonchat — Parent</name>
@@ -30,6 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>21</java.version>
+    <revision>1.6.4</revision>
     <!-- Shared library versions -->
     <adventure.version>5.0.1</adventure.version>
     <luckperms.version>5.5</luckperms.version>

--- a/v1_16_R3/pom.xml
+++ b/v1_16_R3/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_16_R3</artifactId>

--- a/v1_17_R1/pom.xml
+++ b/v1_17_R1/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_17_R1</artifactId>

--- a/v1_18_R2/pom.xml
+++ b/v1_18_R2/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_18_R2</artifactId>

--- a/v1_19_R3/pom.xml
+++ b/v1_19_R3/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_19_R3</artifactId>

--- a/v1_20_R4/pom.xml
+++ b/v1_20_R4/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_20_R4</artifactId>

--- a/v1_21_R1/pom.xml
+++ b/v1_21_R1/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v1_21_R1</artifactId>

--- a/v26_1_R1/pom.xml
+++ b/v26_1_R1/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v26_1_R1</artifactId>

--- a/v26_2_R1/pom.xml
+++ b/v26_2_R1/pom.xml
@@ -8,7 +8,7 @@
   <parent>
     <groupId>com.nonxedy.nonchat</groupId>
     <artifactId>nonchat-parent</artifactId>
-    <version>1.6.3</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>nonchat-v26_2_R1</artifactId>


### PR DESCRIPTION
## Detailed changes - version 1.6.4

### Multi-world chat channels
- Added support for channels that span multiple worlds.
- Channel world scope can now be configured using:
  - a single world;
  - a list of worlds;
  - a map of worlds with individual chat radii.
- World-specific channels can use different radius values per world.
- Players in different worlds can communicate through the same world-scoped channel when the channel configuration allows it.
- Radius-based channels still restrict local messages to players in the same world.
- Updated `/channel create`, `/channel edit`, and `/channel info` to support and display multi-world channel settings.
- Extended the public `Channel` API with `getWorlds()` and `getWorldRadii()`.

Example configuration:

```yml
channels:
  local:
    radius:
      world: 100
      world_nether: 50
      world_the_end: -1
```

### Private-message world separation
- Added optional world-based separation for private messages.
- When enabled, players can send private messages only to players in:
  - the same world; or
  - worlds included in the same configured world group.
- Players outside the sender’s private-message scope are treated as unavailable, preventing information leakage through private-message commands.
- World restrictions also apply to:
  - `/msg`;
  - `/reply`;
  - private-message tab completion;
  - mention suggestions inside private messages;
  - spy-message delivery.
- Players with `nonchat.spy.all` can still receive all spy messages regardless of world separation.
- The feature is disabled by default.

New configuration section:

```yml
private-chat:
  world-separation:
    enabled: false
    groups:
      main:
        - world
        - world_nether
        - world_the_end
```

### Mention improvements
- Added the `mentions.allow-without-at` option.
- When enabled, typing an online player’s name can trigger a mention without requiring the `@` prefix.
- The option is disabled by default, preserving the existing `@PlayerName` behavior.
- Reworked mention detection to use static patterns and exact online-player matching, improving consistency and avoiding per-message regular-expression creation.
- Mention coloring only affects valid online player names when mentions without `@` are enabled.

New configuration section:

```yml
mentions:
  allow-without-at: false
```

### Security and PlaceholderAPI handling
- Improved PlaceholderAPI processing order for chat formats, hover text, interactive placeholders, item data, lore, and click actions.
- PlaceholderAPI is now evaluated only for administrator-configured templates before dynamic player-controlled or item-derived content is inserted.
- This prevents dynamic chat content from being interpreted as PlaceholderAPI placeholders.

### Stability and memory improvements
- Replaced long-lived `Player` object references with UUIDs in internal runtime collections, including:
  - channel selections;
  - message cooldown tracking;
  - chat bubbles;
  - per-player locks;
  - spy mode.
- This reduces the risk of retaining disconnected player instances in memory.
- Added cleanup for chat bubbles and player runtime state on disconnect.
- Added a null check in damage tracking to prevent an exception when main debug mode is disabled.
- Fixed Adventure API compatibility by replacing `TextComponent.Builder` usage with the more compatible `ComponentBuilder` type.

### Other fixes and maintenance
- Improved configured join/quit sound parsing:
  - supports namespaced keys such as `minecraft:entity.experience_orb.pickup`;
  - supports modern dotted sound keys;
  - supports legacy Bukkit enum-style sound names.
- Updated dependency graph workflow settings.
- Maven resource filtering is now used to insert the project version into plugin resources.